### PR TITLE
build-setup: clean up conf folder

### DIFF
--- a/build-setup.sh
+++ b/build-setup.sh
@@ -299,6 +299,9 @@ export https_proxy=${http_proxy}
 
 mkdir -p ${WORKSPACE}/bin
 
+# clean up conf to make sure default conf take effect
+rm -rvf ${build_dir}/conf/*
+
 # Configure proxies for BitBake
 if [[ -n "${http_proxy}" ]]; then
 


### PR DESCRIPTION
We should clean up the conf folder every build once we keep the build folder data exist for speed up build time. The default conf setting may not work if we not clean up the conf folder.